### PR TITLE
fix: change to use /usr/bin/env instead of /bin/bash

### DIFF
--- a/server/scripts/start.sh
+++ b/server/scripts/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # go to parent directory
 if ! cd "$(dirname "$0")/.."; then exit; fi


### PR DESCRIPTION
On some distributions like NixOS the system does not have `/bin/bash`. This change moves the interpreter to use the result of the systems env command which more distros support.