### PR TITLE
Added the 'asciidoctor' filetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ opts = {
   -- Activate automatic saving only for specified file types.
   condition = function(buf)
     local filetype = vim.fn.getbufvar(buf, "&filetype")
-    local filetypes = { 'asciidoc' } -- List of allowed file types.
+    local filetypes = { 'asciidoc', 'asciidoctor' } -- List of allowed file types.
     return vim.list_contains(filetypes, filetype)
   end,
   -- I think a delay between 1000 and 3000 ms is okay.

--- a/lua/asciidoc-preview/util.lua
+++ b/lua/asciidoc-preview/util.lua
@@ -111,13 +111,14 @@ function M.get_current_line_position_in_percent()
   return position
 end
 
----Returns true if the current buffer type is asciidoc.
+---Returns true if the current buffer type is asciidoc or asciidoctor.
 ---@param bufnr? number
 ---@return boolean
 ---@nodiscard
 function M.is_asciidoc_buffer(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
-  return vim.fn.getbufvar(bufnr, '&filetype') == 'asciidoc'
+  local ft = vim.fn.getbufvar(bufnr, '&filetype')
+  return ft == 'asciidoc' or ft == 'asciidoctor'
 end
 
 ---Returns the list of asciidoc buffers.

--- a/plugin/asciidoc-preview.lua
+++ b/plugin/asciidoc-preview.lua
@@ -29,9 +29,9 @@ end
 local augroup = vim.api.nvim_create_augroup
 local autocmd = vim.api.nvim_create_autocmd
 augroup(vim.g.tigion_asciidocPreview_augroupName, { clear = true })
--- Creates auto commands for filetype `asciidoc`.
+-- Creates auto commands for filetype `asciidoc` and `asciidoctor`.
 autocmd('FileType', {
-  pattern = 'asciidoc',
+  pattern = { 'asciidoc', 'asciidoctor' },
   group = vim.g.tigion_asciidocPreview_augroupName,
   callback = function()
     -- Creates user commands


### PR DESCRIPTION
Just added the additional asciidoctor filetype since that is a default for some other plugins, this way there's no plugin sparing happening.
I'm not using the auto-save feature so I'm not sure how that is working for this but it looked straightforward enough